### PR TITLE
Add local support for EP2520 (Flash_Entry_P / Series 3200) espresso machines

### DIFF
--- a/custom_components/philips_homeid/local_api.py
+++ b/custom_components/philips_homeid/local_api.py
@@ -911,6 +911,23 @@ class PhilipsLocalAPI:
                 got_data = True
                 state.properties.update(filters)
 
+        # Espresso machines (EP/SM models) expose their state on the
+        # "machinestatus" and "configuration" ports. These are queried for
+        # non-airfryer devices; non-espresso devices simply return 422 and are
+        # ignored. The responses populate the ESPRESSO_SENSORS descriptions
+        # (nested_key "machinestatus"/"configuration"). Confirmed on EP2520.
+        if not airfryer:
+            for espresso_port in ("machinestatus", "configuration"):
+                espresso_data = await self._request(device, espresso_port)
+                if espresso_data:
+                    got_data = True
+                    state.properties[espresso_port] = espresso_data
+                    if espresso_port == "machinestatus":
+                        state.power_on = (
+                            state.power_on
+                            or espresso_data.get("mainstate", 0) != 0
+                        )
+
         # Get firmware version info
         firmware = await self.get_firmware_info(device)
         if firmware:

--- a/custom_components/philips_homeid/sensor_descriptions.py
+++ b/custom_components/philips_homeid/sensor_descriptions.py
@@ -26,6 +26,8 @@
 
 from __future__ import annotations
 
+import re
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -68,11 +70,17 @@ def get_device_type(model_name: str) -> str:
     ):
         return "multicooker"
 
+    # Espresso machines. Some models report a marketing/codename prefix before
+    # the EPxxxx/SMxxxx model number (e.g. "Flash_Entry_P EP2520"), so a plain
+    # startswith("ep") is not enough — also match an EP/SM model token anywhere.
     if (
         model_lower.startswith("ep")
         or model_lower.startswith("sm")
         or "espresso" in model_lower
         or "coffee" in model_lower
+        or "flash_entry" in model_lower
+        or re.search(r"\bep\d", model_lower) is not None
+        or re.search(r"\bsm\d", model_lower) is not None
     ):
         return "espresso"
 


### PR DESCRIPTION
## Summary

Adds local-API support for the Philips **EP2520** espresso machine (reported model name `Flash_Entry_P EP2520`, sold as "Series 3200"). Before this change, only the `firmware` update entity was created — no espresso sensors.

Two root causes:

1. **`get_device_type()` model detection** (`sensor_descriptions.py`)
   It only matched an `ep`/`sm` *prefix*. The EP2520 reports `Flash_Entry_P EP2520` (marketing codename first), so it was classified `unknown` → no espresso entities. Now also matches `flash_entry` and an `EP<digit>`/`SM<digit>` token anywhere in the name (via regex). `import re` added to module imports.

2. **`get_full_state()` never queried espresso ports locally** (`local_api.py`)
   For non-airfryer devices, only `status`/`air`/`fltsts` (air purifier) + `firmware` were queried, so `device_state.properties` only ever held `firmware`. Now also queries the `machinestatus` and `configuration` ports for non-airfryer devices. Non-espresso devices return 422 and are ignored. The responses feed the existing `ESPRESSO_SENSORS` descriptions (nested keys `machinestatus`/`configuration`).

## Test plan / confirmation

Tested on a **real EP2520** over local HTTPS. After the change, 13 espresso entities are created, e.g.:

- `machinestatus`: `mainstate`, `brewstat`, `Progress`, `beanlevel`, `wastebean`, `waterlevel`, `Filternr`, `Filterstat`, `Descalestat`, `lasterror`
- `configuration`: `waterhard`, `asotime`, `remotectrl`, `recipelist`, `milksyst`, etc.

No regression expected on other device types: the two extra port probes return 422 on non-espresso devices and are silently skipped.

## Notes

- This PR covers **read** support. The machine reports `remotectrl: true` and a `recipelist`, so command/brew support over a local command port could be a follow-up.
- `Descalestat` appears to reflect the descaling *cycle* status rather than the *need* to descale (it stayed `0` while the descale LED was lit on the unit); the descale-needed signal seems to correlate with `lasterror == 19` — worth confirming with more units.