### PR TITLE
Add power + brew control for local EP/SM espresso machines (EP2520)

### DIFF
--- a/custom_components/philips_homeid/button.py
+++ b/custom_components/philips_homeid/button.py
@@ -146,6 +146,29 @@ AIRFRYER_BUTTONS: tuple[PhilipsHomeIDButtonEntityDescription, ...] = (
 )
 
 
+# Local EP/SM espresso machine brew buttons (command/BasicRecipe port).
+# Built-in drinks confirmed on EP2520; brewing first powers the machine on
+# and waits for it to be ready.
+ESPRESSO_BREW_BUTTONS: tuple[PhilipsHomeIDButtonEntityDescription, ...] = (
+    PhilipsHomeIDButtonEntityDescription(
+        key="espresso_brew_espresso",
+        translation_key="espresso_brew_espresso",
+        icon="mdi:coffee",
+        press_fn=lambda c: c.async_espresso_brew_espresso(),
+        available_key="machinestatus",
+        local_only=True,
+    ),
+    PhilipsHomeIDButtonEntityDescription(
+        key="espresso_brew_coffee",
+        translation_key="espresso_brew_coffee",
+        icon="mdi:coffee-outline",
+        press_fn=lambda c: c.async_espresso_brew_coffee(),
+        available_key="machinestatus",
+        local_only=True,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -163,8 +186,14 @@ async def async_setup_entry(
         button_descriptions = AIRFRYER_BUTTONS
         watch_prop = ("status", "airfryer")
     elif device_type == "espresso":
-        button_descriptions = RITA_BUTTONS
-        watch_prop = ("McState", "airfryer")
+        if coordinator.mqtt_client is None:
+            # Local EP/SM espresso machine (e.g. EP2520) via the command port
+            button_descriptions = ESPRESSO_BREW_BUTTONS
+            watch_prop = ("machinestatus", None)
+        else:
+            # Rita espresso machine (FUSION / cloud)
+            button_descriptions = RITA_BUTTONS
+            watch_prop = ("McState", "airfryer")
     else:
         _LOGGER.debug("Skipping button entities for device: %s", model_name)
         return

--- a/custom_components/philips_homeid/coordinator.py
+++ b/custom_components/philips_homeid/coordinator.py
@@ -313,6 +313,14 @@ class PhilipsHomeIDCoordinator(DataUpdateCoordinator[LocalDeviceState | None]):
             if not power_on:
                 return await self.async_airfryer_stop()
             return True
+        # Local EP/SM espresso machines: command port power enum (2=on, 1=off)
+        if device_type == "espresso" and not self._is_fusion:
+            result = await self.api.set_espresso_power(self.device_info, power_on)
+            if result:
+                if self._state:
+                    self._state.power_on = power_on
+                await self.async_request_refresh()
+            return result
         result = await self.api.set_power(self.device_info, power_on)
         if result:
             if self._state:
@@ -638,6 +646,76 @@ class PhilipsHomeIDCoordinator(DataUpdateCoordinator[LocalDeviceState | None]):
         return await self.async_rita_brew_builtin(
             self._rita_brew_profile_id, self.RITA_DRINK_HOT_WATER
         )
+
+    # Local EP/SM espresso machine brew (command/BasicRecipe port).
+    # Distinct from the Rita (FUSION/cloud) brew above. Built-in drinks
+    # confirmed on EP2520: espresso = recipe 2 (40 ml), coffee = recipe 6
+    # (120 ml). RecipeBookIds come from configuration.recipelist.
+    async def _ensure_espresso_ready(self, timeout: int = 90) -> bool:
+        """Power the espresso machine on and wait until ready (mainstate 2)."""
+        status = await self.api.get_espresso_status(self.device_info)
+        mainstate = (status or {}).get("mainstate", 0)
+        if mainstate == 2:
+            return True
+        if mainstate in (3, 5):  # already brewing / needs attention
+            _LOGGER.warning(
+                "Espresso machine not ready to brew (mainstate=%s)", mainstate
+            )
+            return False
+        if mainstate in (0, 1):  # off / standby -> power on
+            await self.api.set_espresso_power(self.device_info, True)
+        # Heating from cold can take a while; poll for the ready state.
+        elapsed = 0
+        while elapsed < timeout:
+            await asyncio.sleep(3)
+            elapsed += 3
+            status = await self.api.get_espresso_status(self.device_info)
+            mainstate = (status or {}).get("mainstate", 0)
+            if mainstate == 2:
+                return True
+            if mainstate == 5:
+                _LOGGER.warning("Espresso machine needs attention (mainstate=5)")
+                return False
+        _LOGGER.warning("Timed out waiting for espresso machine to be ready")
+        return False
+
+    async def async_espresso_brew(
+        self,
+        recipe_id: int,
+        prim_dose: int,
+        *,
+        gr_dose: int = 2,
+        sec_dose: int = 0,
+        temperature: int = 2,
+        nr_of_brews: int = 0,
+    ) -> bool:
+        """Brew a drink on a local EP/SM espresso machine.
+
+        Powers the machine on and waits for it to be ready before sending the
+        recipe, mirroring the HomeID app's behaviour.
+        """
+        if not await self._ensure_espresso_ready():
+            return False
+        result = await self.api.espresso_brew(
+            self.device_info,
+            recipe_id,
+            prim_dose,
+            gr_dose=gr_dose,
+            sec_dose=sec_dose,
+            temperature=temperature,
+            nr_of_brews=nr_of_brews,
+        )
+        if result:
+            await self.async_request_refresh()
+        return result
+
+    async def async_espresso_brew_espresso(self) -> bool:
+        """Brew a built-in espresso (RecipeBookId 2, 40 ml)."""
+        return await self.async_espresso_brew(2, 40)
+
+    async def async_espresso_brew_coffee(self) -> bool:
+        """Brew a built-in coffee (RecipeBookId 6, 120 ml)."""
+        return await self.async_espresso_brew(6, 120)
 
     def _rita_current_roast_level(self) -> int:
         """Return the roast level the machine last reported, or 0."""

--- a/custom_components/philips_homeid/local_api.py
+++ b/custom_components/philips_homeid/local_api.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import secrets
 from typing import Any
 
 import aiohttp
@@ -57,12 +58,15 @@ from .local_models import (  # noqa: F401
     PORT_AIR,
     PORT_AIRFRYER,
     PORT_AUTOCOOK,
+    PORT_COMMAND,
+    PORT_COMMAND_BASICRECIPE,
     PORT_CONTROL,
     PORT_DEVCURRSTATE,
     PORT_DEVICE,
     PORT_FIRMWARE,
     PORT_FLTSTS,
     PORT_HERMESAC,
+    PORT_MACHINESTATUS,
     PORT_NUTRIMAX,
     PORT_RECIPE,
     PORT_SECURITY,
@@ -367,6 +371,58 @@ class PhilipsLocalAPI:
         """Set child lock state."""
         data = {"cl": locked}
         result = await self._request(device, PORT_STATUS, method="PUT", data=data)
+        return result is not None
+
+    # EP/SM espresso machine methods (e.g. EP2520). The "command" port's
+    # "power" field is a mode enum, not a boolean: 2 = on, 1 = standby/off
+    # (0 is the idle readback value). Confirmed on a real EP2520 by capturing
+    # the HomeID app's local HTTPS traffic.
+    async def set_espresso_power(
+        self, device: LocalDeviceInfo, power_on: bool
+    ) -> bool:
+        """Power an espresso machine on (2) or to standby (1)."""
+        data = {"power": 2 if power_on else 1}
+        result = await self._request(
+            device, PORT_COMMAND, method="PUT", data=data
+        )
+        return result is not None
+
+    async def get_espresso_status(
+        self, device: LocalDeviceInfo
+    ) -> dict[str, Any] | None:
+        """Read the espresso machinestatus port (contains mainstate)."""
+        return await self._request(device, PORT_MACHINESTATUS)
+
+    async def espresso_brew(
+        self,
+        device: LocalDeviceInfo,
+        recipe_id: int,
+        prim_dose: int,
+        *,
+        gr_dose: int = 2,
+        sec_dose: int = 0,
+        temperature: int = 2,
+        nr_of_brews: int = 0,
+    ) -> bool:
+        """Start a brew via the command/BasicRecipe sub-port.
+
+        The machine must already be powered on and ready (mainstate 2).
+        Confirmed drinks on EP2520: espresso = RecipeBookId 2 / PrimDose 40 ml,
+        coffee = RecipeBookId 6 / PrimDose 120 ml. PrimDose is the water volume
+        in ml; GrDose is the grind/coffee dose; randnr is a per-request nonce.
+        """
+        data = {
+            "RecipeBookId": recipe_id,
+            "GrDose": gr_dose,
+            "PrimDose": prim_dose,
+            "SecDose": sec_dose,
+            "Temperature": temperature,
+            "NrOfBrews": nr_of_brews,
+            "randnr": secrets.randbelow(2**31),
+        }
+        result = await self._request(
+            device, PORT_COMMAND_BASICRECIPE, method="PUT", data=data
+        )
         return result is not None
 
     # Airfryer-specific methods
@@ -923,9 +979,10 @@ class PhilipsLocalAPI:
                     got_data = True
                     state.properties[espresso_port] = espresso_data
                     if espresso_port == "machinestatus":
+                        # mainstate 1 = standby (off); 2+ = ready/brewing/etc (on)
                         state.power_on = (
                             state.power_on
-                            or espresso_data.get("mainstate", 0) != 0
+                            or espresso_data.get("mainstate", 0) >= 2
                         )
 
         # Get firmware version info

--- a/custom_components/philips_homeid/local_models.py
+++ b/custom_components/philips_homeid/local_models.py
@@ -61,6 +61,11 @@ PORT_RECIPE = "recipe"  # VENUS recipe status
 # Multicooker ports
 PORT_NUTRIMAX = "nutrimax"  # Nutrimax multicooker (NX0960)
 PORT_HERMESAC = "hermesac"  # Hermes appliance (NX0950)
+# EP/SM espresso machine ports (e.g. EP2520 "Flash_Entry_P")
+PORT_MACHINESTATUS = "machinestatus"  # espresso state (mainstate, brewstat, ...)
+PORT_CONFIGURATION = "configuration"  # espresso config (recipelist, remotectrl, ...)
+PORT_COMMAND = "command"  # espresso command port: {"power": 2=on/1=off}
+PORT_COMMAND_BASICRECIPE = "command/BasicRecipe"  # espresso brew sub-port
 
 # Model-to-port mapping: avoids probing all ports and overwhelming
 # the device's limited web server.

--- a/custom_components/philips_homeid/sensor_descriptions.py
+++ b/custom_components/philips_homeid/sensor_descriptions.py
@@ -821,6 +821,15 @@ ESPRESSO_SENSORS: tuple[PhilipsHomeIDSensorEntityDescription, ...] = (
         device_types=("espresso",),
     ),
     PhilipsHomeIDSensorEntityDescription(
+        key="espresso_bean_level",
+        translation_key="espresso_bean_level",
+        property_key="beanlevel",
+        nested_key="machinestatus",
+        icon="mdi:seed-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_types=("espresso",),
+    ),
+    PhilipsHomeIDSensorEntityDescription(
         key="espresso_descale_status",
         translation_key="espresso_descale_status",
         property_key="Descalestat",

--- a/custom_components/philips_homeid/switch.py
+++ b/custom_components/philips_homeid/switch.py
@@ -73,6 +73,10 @@ async def async_setup_entry(
     if device_type == "espresso" and entry.data.get(CONF_IS_FUSION):
         entities.append(PhilipsHomeIDPowerSwitch(coordinator, coordinator.device_id))
 
+    # Power switch for local EP/SM espresso machines (command port power enum)
+    if device_type == "espresso" and not entry.data.get(CONF_IS_FUSION):
+        entities.append(PhilipsHomeIDPowerSwitch(coordinator, coordinator.device_id))
+
     # Preheat toggle for airfryers
     if device_type in (
         "airfryer",

--- a/custom_components/philips_homeid/translations/en.json
+++ b/custom_components/philips_homeid/translations/en.json
@@ -306,6 +306,9 @@
       "espresso_water_level": {
         "name": "Water Level"
       },
+      "espresso_bean_level": {
+        "name": "Bean Level"
+      },
       "espresso_descale_status": {
         "name": "Descale Status"
       },
@@ -462,6 +465,12 @@
       },
       "rita_brew_hot_water": {
         "name": "Brew Hot Water"
+      },
+      "espresso_brew_espresso": {
+        "name": "Brew Espresso"
+      },
+      "espresso_brew_coffee": {
+        "name": "Brew Coffee"
       }
     },
     "number": {

--- a/custom_components/philips_homeid/translations/fr.json
+++ b/custom_components/philips_homeid/translations/fr.json
@@ -306,6 +306,9 @@
       "espresso_water_level": {
         "name": "Niveau d'eau"
       },
+      "espresso_bean_level": {
+        "name": "Niveau de grains"
+      },
       "espresso_descale_status": {
         "name": "État détartrage"
       },
@@ -459,6 +462,12 @@
       },
       "rita_brew_hot_water": {
         "name": "Eau chaude"
+      },
+      "espresso_brew_espresso": {
+        "name": "Préparer un espresso"
+      },
+      "espresso_brew_coffee": {
+        "name": "Préparer un café"
       }
     },
     "number": {

--- a/docs/EP2520_LOCAL_PROTOCOL.md
+++ b/docs/EP2520_LOCAL_PROTOCOL.md
@@ -1,0 +1,111 @@
+# EP2520 / EP-SM Espresso Machines — Local Control Protocol
+
+This documents the **local** (LAN) control protocol for Philips/Saeco EP and SM
+series espresso machines, confirmed on an **EP2520** (`Flash_Entry_P`, sold as
+"Series 3200", CTN `EP2520/10`, sw `00.06.04`). Read support landed in #20; this
+covers **power** and **brew** control.
+
+These machines speak the same `PHILIPS-Condor` HTTPS protocol as the airfryers
+(see `APK_DECOMPILED_ANALYSIS.md` §0 for the challenge-response auth and TLS
+notes). They stay reachable on the LAN **while in standby**, and — importantly —
+the HomeID app drives power/brew over this **local** path, not the cloud. There
+is **no certificate pinning on the local device connection**, so the protocol
+below was captured with a plain proxy (mitmproxy) and the app's normal traffic.
+
+All requests are authenticated with the cached `Authorization: PHILIPS-Condor …`
+header and target product id `1` unless noted.
+
+## Ports
+
+| Port | Method | Purpose |
+|------|--------|---------|
+| `/di/v1/products/1/machinestatus` | GET | Machine state (`mainstate`, `brewstat`, levels, errors) |
+| `/di/v1/products/1/configuration` | GET | Config (`recipelist`, `remotectrl`, water hardness, …) |
+| `/di/v1/products/1/command` | GET/PUT | Power + brew command port |
+| `/di/v1/products/1/command/BasicRecipe` | PUT | Start a brew (recipe sub-resource) |
+| `/di/v1/products/1/device` | GET | Device info (name, type, CTN, sw version) |
+| `/di/v1/products/0/firmware` | GET | Firmware info |
+
+### `command` port
+
+```json
+{ "power": 0, "processctrl": 0, "BasicRecipe": {} }
+```
+
+- **`power`** is a *mode enum, not a boolean*. It is **momentary** — the device
+  consumes the written value and the field reads back as `0` afterwards.
+  - `2` → **power ON** (machine wakes; from cold it runs a rinse)
+  - `1` → **power OFF / standby**
+  - `0` → idle (the readback / no-op value)
+- **`processctrl`** — brew process control (not yet decoded; left at `0`).
+- **`BasicRecipe`** — the recipe currently being brewed (empty when idle).
+
+Power on: `PUT /di/v1/products/1/command  {"power": 2}`
+Power off: `PUT /di/v1/products/1/command  {"power": 1}`
+
+### `machinestatus.mainstate`
+
+| value | meaning |
+|------|---------|
+| 1 | standby (off) |
+| 2 | ready |
+| 3 | brewing |
+| 4 | processing (heating / rinsing) |
+| 5 | action required (e.g. refill) |
+
+> Note: `mainstate == 1` is "off" from the user's perspective, even though the
+> device still answers on the network. A power/on indicator should treat
+> `mainstate >= 2` as "on".
+
+## Brewing
+
+Brewing is a **`PUT` to the `command/BasicRecipe` sub-resource**, sent **after**
+the machine is powered on and `mainstate == 2` (ready). The HomeID app powers on,
+polls `machinestatus` until ready, then writes the recipe.
+
+```
+PUT /di/v1/products/1/command/BasicRecipe
+{
+  "RecipeBookId": 2,     // drink id (see recipelist)
+  "GrDose": 2,           // grind / coffee dose (strength)
+  "PrimDose": 40,        // primary water volume, ml
+  "SecDose": 0,          // secondary volume (2nd cup / milk), ml
+  "Temperature": 2,      // temperature setting
+  "NrOfBrews": 0,        // 0 = single
+  "randnr": 1328873381   // per-request random nonce
+}
+```
+
+### Drink ids (`RecipeBookId`)
+
+`configuration.recipelist` enumerates the drinks the machine offers (`255` = empty
+slot). On the EP2520 this was `[2, 6, 21, 26, 255, 255]`. Ids match the APK
+`RitaDrinkKt` enum. Confirmed by capture:
+
+| RecipeBookId | Drink | PrimDose (ml) captured |
+|--------------|-------|------------------------|
+| 2 | Espresso | 40 |
+| 6 | Coffee | 120 |
+| 21 | Hot Water | — (per APK `RitaDrinkKt`) |
+| 26 | (machine-specific) | — |
+
+`PrimDose` is the water volume in ml and is the main per-drink difference
+(espresso 40 ml vs long coffee 120 ml); the other fields were identical across
+the two captured drinks.
+
+## Captured examples
+
+Espresso:
+```
+PUT /di/v1/products/1/command          {"power": 2}
+PUT /di/v1/products/1/command/BasicRecipe
+    {"RecipeBookId":2,"GrDose":2,"PrimDose":40,"SecDose":0,
+     "Temperature":2,"NrOfBrews":0,"randnr":1328873381}
+```
+
+Coffee (long):
+```
+PUT /di/v1/products/1/command/BasicRecipe
+    {"RecipeBookId":6,"GrDose":2,"PrimDose":120,"SecDose":0,
+     "Temperature":2,"NrOfBrews":0,"randnr":1767779466}
+```


### PR DESCRIPTION
## Summary

Follow-up to #20 (read support). Adds **remote power on/off** and **built-in
drink brewing** for locally-connected EP/SM espresso machines, plus a **Bean
Level** sensor. Confirmed on a real **EP2520** (`Flash_Entry_P`, "Series 3200").

These machines drive power/brew over the **local** `PHILIPS-Condor` HTTPS path
(not the cloud) and stay reachable in standby. The protocol was reverse-engineered
by capturing the HomeID app's local traffic — there is no cert pinning on the
local device connection. Full write-up in `docs/EP2520_LOCAL_PROTOCOL.md`.

## Protocol (short version)

- **Power** — `PUT /di/v1/products/1/command  {"power": <mode>}` where the
  `power` field is a *mode enum*, momentary (reads back `0`): **`2` = on,
  `1` = standby/off**.
- **Brew** — after power-on and once `machinestatus.mainstate == 2` (ready):
  `PUT /di/v1/products/1/command/BasicRecipe` with
  `{RecipeBookId, GrDose, PrimDose(ml), SecDose, Temperature, NrOfBrews, randnr}`.
  Drink ids come from `configuration.recipelist`. Captured: espresso = recipe `2`
  / 40 ml, coffee = recipe `6` / 120 ml (`21` = hot water per the APK enum).
- `mainstate`: 1 standby, 2 ready, 3 brewing, 4 processing, 5 action-required.

## Changes

- `local_api`: `set_espresso_power`, `espresso_brew`, `get_espresso_status` +
  `PORT_COMMAND` / `PORT_COMMAND_BASICRECIPE` / `PORT_MACHINESTATUS` / `PORT_CONFIGURATION`.
- `coordinator`: route local-espresso `async_set_power` to the command port;
  `async_espresso_brew` powers on and waits for "ready" before sending the recipe
  (mirrors the app). Takes all recipe params so per-drink customisation is a small
  follow-up.
- `switch`: **Power** switch for local (non-FUSION) espresso machines.
- `button`: **Brew Espresso** (recipe 2 / 40 ml) and **Brew Coffee** (recipe 6 / 120 ml).
- `sensor`: **Bean Level** (`machinestatus.beanlevel`).
- Fix `power_on` flag: `mainstate == 1` is standby (off); on is `mainstate >= 2`.
- `en`/`fr` translations for the new entities.

## Test plan

Verified end-to-end on a real EP2520 via the HA entities:

- [x] Power switch on: standby (`mainstate 1`) → wakes (`4`/`2`)
- [x] Power switch off (from ready): `mainstate 2` → `1`
- [x] Brew Espresso button: machine powers on, heats to ready, brews an espresso
- [x] Brew Coffee payload captured directly from the app (recipe 6 / 120 ml)
- [x] Bean Level sensor reads the machine's `beanlevel`
- [x] No regression to read support (other device types unaffected; new code paths gated on `device_type == "espresso"` + local/non-FUSION)

## Notes

- `processctrl` (in the command port) and `RecipeBookId 26` aren't decoded yet.
- Adjustable per-drink parameters (volume/strength/temp via number/select entities)
  are a natural follow-up — `async_espresso_brew` already accepts them.